### PR TITLE
refactor: integrate LLM service into extraction pipeline

### DIFF
--- a/src/vinyl_preflight/core/extraction.py
+++ b/src/vinyl_preflight/core/extraction.py
@@ -5,13 +5,14 @@ import concurrent.futures
 import logging
 
 from vinyl_preflight.core.pdf_utils import extract_text_from_pdf
+from vinyl_preflight.llm.service import LLMExtractionService
 
 logger = logging.getLogger(__name__)
 
 MAX_PARALLEL_API_REQUESTS = 10
 
 
-def process_single_extraction_batch(batch: List[Path]) -> Optional[List[Dict]]:
+def process_single_extraction_batch(batch: List[Path], llm_service: LLMExtractionService) -> Optional[List[Dict]]:
     documents_to_process: List[Dict[str, str]] = []
     for pdf_path in batch:
         try:
@@ -30,18 +31,19 @@ def process_single_extraction_batch(batch: List[Path]) -> Optional[List[Dict]]:
         except Exception as e:
             logger.error(f"Unexpected error reading PDF: {pdf_path.name}, {e}")
             documents_to_process.append({"identifier": pdf_path.as_posix(), "content": f"CHYBA: Neočekávaná chyba. {e}"})
+
     if not documents_to_process:
         return None
-    # Ponecháváme návratovou strukturu kompatibilní s monolitem: list(result dicts)
-    # Samotné LLM volání zůstává v monolitu pro nynější krok přesunu.
-    return [{"source_identifier": d["identifier"], "status": "success", "data": []} for d in documents_to_process]
+
+    # Nyní používáme LLM service pro extrakci
+    return llm_service.extract_tracks_from_documents(documents_to_process)
 
 
-def process_all_pdf_batches(batches: List[List[Path]], status_callback, progress_callback) -> dict:
+def process_all_pdf_batches(batches: List[List[Path]], llm_service: LLMExtractionService, status_callback, progress_callback) -> dict:
     all_results: Dict[str, Dict] = {}
     total_batches = len(batches)
     with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_PARALLEL_API_REQUESTS) as executor:
-        future_to_batch = {executor.submit(process_single_extraction_batch, batch): i for i, batch in enumerate(batches)}
+        future_to_batch = {executor.submit(process_single_extraction_batch, batch, llm_service): i for i, batch in enumerate(batches)}
         for i, future in enumerate(concurrent.futures.as_completed(future_to_batch)):
             status_callback(f"4/5 Zpracovávám PDF dávku {i+1}/{total_batches}...")
             progress_callback(i + 1, total_batches)

--- a/src/vinyl_preflight/llm/service.py
+++ b/src/vinyl_preflight/llm/service.py
@@ -1,0 +1,69 @@
+import json
+import logging
+from typing import List, Dict, Optional
+from pathlib import Path
+
+from vinyl_preflight.llm.client import LLMClient
+
+logger = logging.getLogger(__name__)
+
+
+class LLMExtractionService:
+    def __init__(self, llm_client: LLMClient, detailed_logger=None):
+        self.llm_client = llm_client
+        self.detailed_logger = detailed_logger
+
+    def extract_tracks_from_documents(self, documents_to_process: List[Dict]) -> Optional[List[Dict]]:
+        """Extract track information from documents using LLM."""
+        if not documents_to_process:
+            return None
+
+        prompt = f"""
+Jsi expert na hudební mastering. Tvým úkolem je precizně extrahovat informace o skladbách z několika dokumentů.
+Analyzuj KAŽDÝ dokument v poli a vrať VÝHRADNĚ JEDEN JSON objekt s klíčem "results". Hodnota klíče "results" bude pole, kde každý prvek reprezentuje jeden zpracovaný dokument.
+
+Struktura pro každý prvek v poli "results":
+- "source_identifier": Unikátní identifikátor dokumentu.
+- "status": 'success' nebo 'error'.
+- "data": Pokud 'success', zde bude pole skladeb. Každá skladba musí obsahovat "side", "track_number", "title", "duration_seconds".
+- "error_message": Popis chyby, pokud status je 'error'.
+
+Zde jsou dokumenty ke zpracování:
+---
+{json.dumps(documents_to_process, indent=2, ensure_ascii=False)}
+---
+"""
+
+        # Logování LLM požadavku
+        if self.detailed_logger:
+            self.detailed_logger.log_llm_request({
+                "documents_count": len(documents_to_process),
+                "documents": [{"identifier": d["identifier"], "content_length": len(d["content"])} for d in documents_to_process],
+                "prompt_length": len(prompt),
+            })
+
+        try:
+            response = self.llm_client.call(prompt)
+            
+            # Pro OpenRouter response format
+            if "choices" in response:
+                content_str = response["choices"][0]["message"]["content"]
+                parsed_results = json.loads(content_str).get("results", [])
+            else:
+                # Pro mock nebo jiné formáty
+                parsed_results = response.get("results", [])
+
+            # Logování LLM odpovědi
+            if self.detailed_logger:
+                self.detailed_logger.log_llm_response({
+                    "raw_response": response,
+                    "parsed_results": parsed_results,
+                })
+
+            return parsed_results
+
+        except Exception as e:
+            logger.error(f"LLM extraction failed: {e}")
+            if self.detailed_logger:
+                self.detailed_logger.log_llm_error({"error": str(e)})
+            return None

--- a/tests/unit/test_llm_service.py
+++ b/tests/unit/test_llm_service.py
@@ -1,0 +1,19 @@
+from vinyl_preflight.llm.service import LLMExtractionService
+from vinyl_preflight.llm.client import MockLLMClient
+
+def test_llm_service_extraction():
+    mock_client = MockLLMClient()
+    service = LLMExtractionService(mock_client)
+    
+    documents = [{"identifier": "test.pdf", "content": "Track 1: Song A"}]
+    result = service.extract_tracks_from_documents(documents)
+    
+    # Mock client vrací prázdné results, ale service by měl fungovat
+    assert result is not None
+
+def test_llm_service_empty_documents():
+    mock_client = MockLLMClient()
+    service = LLMExtractionService(mock_client)
+    
+    result = service.extract_tracks_from_documents([])
+    assert result is None


### PR DESCRIPTION
This PR completes the LLM integration refactor:

- Add LLMExtractionService in src/vinyl_preflight/llm/service.py
- Update core/extraction.py to use LLM service instead of direct API calls
- Remove old _process_single_extraction_batch from monolith
- Monolith now creates OpenRouterLLMClient and LLMExtractionService
- Add unit tests for LLM service

All tests pass (25 passed, 5 warnings). GUI remains unchanged.

Mapping:
- Monolith LLM API calls → llm.service.LLMExtractionService
- Direct requests.post → llm.client.OpenRouterLLMClient

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

## Summary by Sourcery

Integrate a dedicated LLM extraction service into the PDF extraction pipeline, refactor core extraction functions to use this service instead of direct API calls, remove the old batch processing implementation, and add unit tests for the new service.

New Features:
- Add LLMExtractionService to encapsulate track extraction logic using an LLM client
- Instantiate OpenRouterLLMClient and LLMExtractionService in the main application entrypoint

Enhancements:
- Refactor process_single_extraction_batch and process_all_pdf_batches to delegate to LLMExtractionService
- Replace direct requests.post API calls with LLMClient.call in the service layer

Tests:
- Add unit tests for LLMExtractionService behavior

Chores:
- Remove legacy _process_single_extraction_batch implementation from monolith core