### PR TITLE
refactor: final cleanup - remove redundant monolith methods

### DIFF
--- a/tests/test_vinyl_preflight.py
+++ b/tests/test_vinyl_preflight.py
@@ -108,32 +108,38 @@ class TestConsolidatedModeDetection:
     
     def test_empty_wav_list(self, processor):
         """Test prázdného seznamu WAV"""
-        assert processor._detect_consolidated_mode([]) == False
-    
+        from vinyl_preflight.core.validator import detect_consolidated_mode
+        assert detect_consolidated_mode([]) == False
+
     def test_too_many_wavs(self, processor):
         """Test příliš mnoha WAV souborů (>4)"""
+        from vinyl_preflight.core.validator import detect_consolidated_mode
         wavs = [f"track_{i:02d}.wav" for i in range(1, 6)]
-        assert processor._detect_consolidated_mode(wavs) == False
-    
+        assert detect_consolidated_mode(wavs) == False
+
     def test_individual_tracks(self, processor):
         """Test individual track patterns"""
+        from vinyl_preflight.core.validator import detect_consolidated_mode
         wavs = ["01_track.wav", "02_track.wav", "03_track.wav"]
-        assert processor._detect_consolidated_mode(wavs) == False
-    
+        assert detect_consolidated_mode(wavs) == False
+
     def test_consolidated_sides(self, processor):
         """Test consolidated side patterns"""
+        from vinyl_preflight.core.validator import detect_consolidated_mode
         wavs = ["SIDE A-V2-WAV.wav", "SIDE B-V2-WAV.wav", "SIDE C-V2-WAV.wav"]
-        assert processor._detect_consolidated_mode(wavs) == True
-    
+        assert detect_consolidated_mode(wavs) == True
+
     def test_simple_sides(self, processor):
         """Test jednoduchých side patterns"""
+        from vinyl_preflight.core.validator import detect_consolidated_mode
         wavs = ["A.wav", "B.wav"]
-        assert processor._detect_consolidated_mode(wavs) == True
-    
+        assert detect_consolidated_mode(wavs) == True
+
     def test_mixed_patterns(self, processor):
         """Test smíšených patterns (většina individual)"""
+        from vinyl_preflight.core.validator import detect_consolidated_mode
         wavs = ["01_track.wav", "02_track.wav", "side_a.wav"]
-        assert processor._detect_consolidated_mode(wavs) == False
+        assert detect_consolidated_mode(wavs) == False
 
 
 class TestWAVProcessing:


### PR DESCRIPTION
This PR completes the refactoring cleanup:

- Remove redundant methods from monolith that only delegated to modular functions:
  - _validate_project, _detect_consolidated_mode, _find_wav_for_side
  - _validate_consolidated_project, _validate_individual_project
- Remove unused imports (re, thefuzz) since they're now in modules
- Update tests to use modular functions directly instead of monolith methods
- All tests pass (30 passed, 5 warnings)

Monolith is now significantly smaller and cleaner. GUI remains unchanged.

Lines removed: 171
Lines added: 22

The refactor is complete - monolith now delegates to modular architecture.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

## Summary by Sourcery

Finalize refactoring by removing redundant validation methods from the monolithic app and updating tests to call the modular core functions directly

Enhancements:
- Remove monolith methods that merely delegated to modular validation functions (_validate_project, _detect_consolidated_mode, _find_wav_for_side, _validate_consolidated_project, _validate_individual_project)
- Eliminate unused imports (re, thefuzz) now relocated to core modules

Tests:
- Update tests to import and use detect_consolidated_mode from the core validator module instead of monolith methods